### PR TITLE
Export useHydrate to init store with Data from SSG/SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,13 @@ import uC from './useCroods'
 import uS from './useStore'
 import Context, { CProvider } from './Context'
 import FetchComponent from './Fetch'
+import store from './store'
+import uH from './useHydrate'
 
 export const useCroods = uC
 export const useStore = uS
+export const useCroodsStore = store
+export const useHydrate = uH
 export const CroodsProvider = CProvider
 export const CroodsContext = Context
 export const Fetch = FetchComponent
@@ -12,6 +16,8 @@ export const Fetch = FetchComponent
 export default {
   useCroods,
   useStore,
+  useCroodsStore,
+  useHydrate,
   CroodsProvider,
   CroodsContext,
   Fetch,

--- a/src/typeDeclarations.ts
+++ b/src/typeDeclarations.ts
@@ -67,6 +67,13 @@ export interface InstanceOptions extends ProviderOptions {
   fetchOnMount?: boolean
 }
 
+export interface HydrateOptions {
+  name: string
+  stateId?: ID
+  type?: 'list' | 'info'
+  value: any
+}
+
 type HTTPMethod = 'POST' | 'PUT' | 'PATCH'
 
 export interface ActionOptions extends ProviderOptions {

--- a/src/useHydrate.tsx
+++ b/src/useHydrate.tsx
@@ -1,0 +1,47 @@
+import { useState, useContext, useEffect } from 'react'
+import toUpper from 'lodash/toUpper'
+
+import { ProviderOptions, InstanceOptions, HydrateOptions } from './typeDeclarations';
+
+import Context from './Context'
+import findStatePiece from './findStatePiece'
+import { consoleGroup } from './logger'
+import { findPath } from './findStatePiece'
+import useGlobal from './store'
+
+const useHydrate = ({
+  type = 'list',
+  name,
+  stateId,
+  value,
+}: HydrateOptions, config?: ProviderOptions) => {
+  if (typeof name !== 'string' || name.length < 1) {
+    throw new Error('You must pass a name property to useHydrate')
+  }
+  const [hydrated, setHydrated] = useState(false)
+
+  const baseOptions: ProviderOptions = useContext(Context)
+  const options: InstanceOptions = { name, ...baseOptions, ...config }
+  const contextPath: string = findPath(name, stateId)
+  const [state, { setInfo, setList }] = useGlobal(contextPath)
+
+  useEffect(() => {
+    if (type === 'list') {
+      setList({ name: contextPath }, value)
+    }
+    if (type === 'info') {
+      setInfo({ name: contextPath }, value)
+    }
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (hydrated && options.debugActions) {
+      const statePiece = findStatePiece(state, name, stateId)
+      const title = `${toUpper(type)} HYDRATE [${contextPath}]`
+      consoleGroup(title, 'cornflowerblue')(statePiece, state)
+    }
+  }, [hydrated, options.debugActions])
+}
+
+export default useHydrate


### PR DESCRIPTION
The data gets into the Store before any Croods actions and persists state between SSG/SSR pages.

In the screenshot below I changed from Faq -> Home and the Faqs persisted

![Captura de Tela 2020-06-11 às 14 10 50](https://user-images.githubusercontent.com/566971/84418655-dd806700-abed-11ea-8076-9933c5a8b1ed.png)
