### PR TITLE
Add easier typing to Actions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,14 +37,20 @@ type CroodsState<T extends any = any> = {
   saving: boolean
 }
 
+type Destroy<T = any> = <B = T>(
+  a?: ActionOptions,
+) => (b?: QueryStringObj) => Promise<Info<B>>
+type Fetch<T = any> = <B = T>(a?: ActionOptions) => (b?: QueryStringObj) => Promise<Info<B>>
+type Save<T = any> = <B = T>(a?: SaveOptions) => (b?: ReqBody) => Promise<Info<B>>
+type SetInfo<T = any> = <B = Partial<T>>(a: B, b?: boolean) => void
+type SetList<T = any> = <B = T>(a: B[], b?: boolean) => void
+
 type Actions<T = any> = {
-  destroy: <B = T>(
-    a?: ActionOptions,
-  ) => (b?: QueryStringObj) => Promise<Info<B>>
-  fetch: <B = T>(a?: ActionOptions) => (b?: QueryStringObj) => Promise<Info<B>>
-  save: <B = T>(a?: SaveOptions) => (b?: ReqBody) => Promise<Info<B>>
-  setInfo: <B = Partial<T>>(a: B, b?: boolean) => void
-  setList: <B = T>(a: B[], b?: boolean) => void
+  destroy: Destroy<T>
+  fetch: Fetch<T>
+  save: Save<T>
+  setInfo: SetInfo<T>
+  setList: SetList<T>
 }
 
 type HeadersObj = Record<string, string>


### PR DESCRIPTION
PS: My prettier changes almost ALL files in the project, so I commited without running it. That's why tests fail.

This PR has the goal to make easier Actions types importing.

In day-to-day usage, I'd copy the VS Code type suggestion in order to type component properties. But the type suggestion of `save` (an example) is like this in VS Code:

```ts
var save: <B = Conversation>(a?: SaveOptions | undefined) => (b?: ReqBody | undefined) => Promise<Info<B>>
```

So I'd need to write something like this in my componente:

```ts
type Props = {
  save: <B = Conversation>(a?: SaveOptions | undefined) => (b?: ReqBody | undefined) => Promise<Info<B>>
}
```

So, after going through the source code, I discovered I could do this:

```ts
type Props = {
  save: Actions['save']
}
```

I thought: a beginner in typescript maybe wouldn't know this is possible. So I suggest these changes to make something like this possible:

```ts
type Props = {
  save: Save
}
```