### PR TITLE
Reset state

### DIFF
--- a/docs/docs/mainconcepts.md
+++ b/docs/docs/mainconcepts.md
@@ -47,6 +47,7 @@ actions = {
   destroy: config => query => {...},
   setInfo: data => {...},
   setList: data => {...},
+  dangerouslyResetCroodsState: () => void
 }
 ```
 
@@ -106,7 +107,7 @@ You can [override this behavior](/docs/the-actions#save) though.
 
 #### Destroy
 
-Lastly, for the `DELETE` method you'll have the `destroy` action:
+For the `DELETE` method you'll have the `destroy` action:
 
 ```
 <button onClick={destroy({ id: 1 })} />

--- a/docs/docs/mainconcepts.md
+++ b/docs/docs/mainconcepts.md
@@ -47,6 +47,7 @@ actions = {
   destroy: config => query => {...},
   setInfo: data => {...},
   setList: data => {...},
+  resetState: options => void
   dangerouslyResetCroodsState: () => void
 }
 ```

--- a/docs/docs/mainconcepts.md
+++ b/docs/docs/mainconcepts.md
@@ -48,7 +48,7 @@ actions = {
   setInfo: data => {...},
   setList: data => {...},
   resetState: options => void
-  dangerouslyResetCroodsState: () => void
+  dangerouslyClearCroodsState: () => void
 }
 ```
 

--- a/docs/docs/the-actions.md
+++ b/docs/docs/the-actions.md
@@ -18,7 +18,7 @@ const [state, actions] = useCroods({ name: 'images' })
 Now you can use all of the following actions:
 
 ```
-const { fetch, save, destroy, setInfo, setList, dangerouslyResetCroodsState } = actions
+const { fetch, save, destroy, setInfo, setList, resetState, dangerouslyResetCroodsState } = actions
 ```
 
 ## fetch
@@ -276,13 +276,30 @@ const getNew = () => {
 
 # Clearing state
 
+## Reset State
+
+**Format:** `([object]) => void`
+
+In order to reset a single `state.list` to its initial state, you can pass it's name as `options` to `resetState`.
+
+```
+const [, { resetState }] = useCroods({ name: 'todos' })
+const clearAll = () => {
+  myApi.removeUser().then(() => resetState({ name: 'todos' }))
+}
+```
+
+This will clear the state back to its initial values, with every Croods information inside it. The initial state has empty `info` and `list`.
+
 ## Dangerously Reset Croods State
 
 **Format:** `() => void`
 
 This action completely wipes Croods state, replacing it with an empty object `{}`. 
 
-As the name implies, it's a destructive and dangerous operation in the front-end.
+As the name implies, it's a destructive and dangerous operation in the front-end. No requests will be sent to the backend.
+
+Instead of `resetState`, in which you pass which specific piece of state you want to clear and the resulting state is a Croods object (even though it's empty), this action replaces every Croods objects and all Croods information to `{}`.
 
 ```
 const [{}, { dangerouslyResetCroodsState }] = useCroods({ name: 'auth' })
@@ -291,4 +308,3 @@ const signOut = () => {
 }
 ```
 
-No requests will be sent to the backend and the global Croods state will be set `{}`

--- a/docs/docs/the-actions.md
+++ b/docs/docs/the-actions.md
@@ -280,7 +280,7 @@ const getNew = () => {
 
 **Format:** `([object]) => void`
 
-In order to reset a single `state.list` to its initial state, you can pass it's name as `options` to `resetState`.
+In order to reset a single `state.list` to its initial state, you can pass its name as `options` to `resetState`.
 
 ```
 const [, { resetState }] = useCroods({ name: 'todos' })
@@ -289,7 +289,7 @@ const clearAll = () => {
 }
 ```
 
-This will clear the state back to its initial values, with every Croods information inside it. The initial state has empty `info` and `list`.
+This will clear the state back to its [initial values](/docs/main-concepts#state), with every Croods information inside it.
 
 ## Dangerously Clear Croods State
 
@@ -299,7 +299,7 @@ This action completely wipes Croods state, replacing it with an empty object `{}
 
 As the name implies, it's a destructive and dangerous operation in the front-end. No requests will be sent to the backend.
 
-Instead of `resetState`, in which you pass which specific piece of state you want to clear and the resulting state is a Croods object (even though it's empty), this action replaces every Croods objects and all Croods information to `{}`.
+Instead of `resetState`, in which you pass which specific piece of state you want to reset and the resulting state is a [initial Croods state](/docs/main-concepts#state), this action erases every bit of Croods state and all Croods Global state will be set to `{}`.
 
 ```
 const [{}, { dangerouslyClearCroodsState }] = useCroods({ name: 'auth' })

--- a/docs/docs/the-actions.md
+++ b/docs/docs/the-actions.md
@@ -18,7 +18,7 @@ const [state, actions] = useCroods({ name: 'images' })
 Now you can use all of the following actions:
 
 ```
-const { fetch, save, destroy, setInfo, setList, resetState, dangerouslyResetCroodsState } = actions
+const { fetch, save, destroy, setInfo, setList, resetState, dangerouslyClearCroodsState } = actions
 ```
 
 ## fetch
@@ -291,7 +291,7 @@ const clearAll = () => {
 
 This will clear the state back to its initial values, with every Croods information inside it. The initial state has empty `info` and `list`.
 
-## Dangerously Reset Croods State
+## Dangerously Clear Croods State
 
 **Format:** `() => void`
 
@@ -302,9 +302,9 @@ As the name implies, it's a destructive and dangerous operation in the front-end
 Instead of `resetState`, in which you pass which specific piece of state you want to clear and the resulting state is a Croods object (even though it's empty), this action replaces every Croods objects and all Croods information to `{}`.
 
 ```
-const [{}, { dangerouslyResetCroodsState }] = useCroods({ name: 'auth' })
+const [{}, { dangerouslyClearCroodsState }] = useCroods({ name: 'auth' })
 const signOut = () => {
-  myApi.signOut().then(() => dangerouslyResetCroodsState())
+  myApi.signOut().then(() => dangerouslyClearCroodsState())
 }
 ```
 

--- a/docs/docs/the-actions.md
+++ b/docs/docs/the-actions.md
@@ -18,7 +18,7 @@ const [state, actions] = useCroods({ name: 'images' })
 Now you can use all of the following actions:
 
 ```
-const { fetch, save, destroy, setInfo, setList } = actions
+const { fetch, save, destroy, setInfo, setList, dangerouslyResetCroodsState } = actions
 ```
 
 ## fetch
@@ -273,3 +273,22 @@ const getNew = () => {
   // Component will be rerendered with 6 items on list
 }
 ```
+
+# Clearing state
+
+## Dangerously Reset Croods State
+
+**Format:** `() => void`
+
+This action completely wipes Croods state, replacing it with an empty object `{}`. 
+
+As the name implies, it's a destructive and dangerous operation in the front-end.
+
+```
+const [{}, { dangerouslyResetCroodsState }] = useCroods({ name: 'auth' })
+const signOut = () => {
+  myApi.signOut().then(() => dangerouslyResetCroodsState())
+}
+```
+
+No requests will be sent to the backend and the global Croods state will be set `{}`

--- a/docs/docs/use-global.md
+++ b/docs/docs/use-global.md
@@ -103,3 +103,25 @@ return (
 ```
 
 That way you can manage an application-wise state without tampering with Croods state.
+
+## Resetting Croods global state
+
+If the global state of the application ever need to be completely cleared, you can use the action `resetState` instead of the `setState` inside the action:
+
+```tsx
+// src/useGlobal.js
+
+const initialState = {}
+
+const actions = {
+  cleanState: store => {
+    store.resetState()
+  },
+}
+
+export default useStore(actions, initialState)
+```
+
+**Important**: this action _will not_ reset to the initial state. It will, instead, clear the whole state to an empty object `{}`.
+
+One of the probable use cases for this function is clearing the Croods state when the user logs off the application.

--- a/docs/docs/use-global.md
+++ b/docs/docs/use-global.md
@@ -104,6 +104,7 @@ return (
 
 That way you can manage an application-wise state without tampering with Croods state.
 
+
 ## Resetting Croods global state
 
 If the global state of the application ever need to be completely cleared, you can use the action `resetState` instead of the `setState` inside the action:

--- a/src/__tests__/useCroods.test.js
+++ b/src/__tests__/useCroods.test.js
@@ -34,7 +34,7 @@ describe('useCroods hook', () => {
       expect(actions.destroy).toBeDefined()
       expect(actions.setInfo).toBeDefined()
       expect(actions.setList).toBeDefined()
-      expect(actions.dangerouslyResetCroodsState).toBeDefined()
+      expect(actions.dangerouslyClearCroodsState).toBeDefined()
     })
   })
 
@@ -315,7 +315,7 @@ describe('useCroods hook', () => {
     })
   })
 
-  describe('Croods Action: Dangerously Reset Croods State', () => {
+  describe('Croods Action: Dangerously Clear Croods State', () => {
     it('resets crood state gracefully', () => {
       const { result } = renderHook(() => useCroods({ name: 'setInfo' }))
       const [, actions] = result.current
@@ -326,7 +326,7 @@ describe('useCroods hook', () => {
       expect(userList).toEqual([user])
 
       act(() => {
-        actions.dangerouslyResetCroodsState()
+        actions.dangerouslyClearCroodsState()
       })
       const [{ list: emptyList }] = result.current
       expect(emptyList).toEqual([])

--- a/src/__tests__/useCroods.test.js
+++ b/src/__tests__/useCroods.test.js
@@ -34,6 +34,7 @@ describe('useCroods hook', () => {
       expect(actions.destroy).toBeDefined()
       expect(actions.setInfo).toBeDefined()
       expect(actions.setList).toBeDefined()
+      expect(actions.dangerouslyResetCroodsState).toBeDefined()
     })
   })
 
@@ -311,6 +312,24 @@ describe('useCroods hook', () => {
         actions.setList([user2], true)
       })
       expect(result.current[0].list).toEqual([user, user2])
+    })
+  })
+
+  describe('Croods Action: Dangerously Reset Croods State', () => {
+    it('resets crood state gracefully', () => {
+      const { result } = renderHook(() => useCroods({ name: 'setInfo' }))
+      const [, actions] = result.current
+      act(() => {
+        actions.setList([user])
+      })
+      const [{ list: userList }] = result.current
+      expect(userList).toEqual([user])
+
+      act(() => {
+        actions.dangerouslyResetCroodsState()
+      })
+      const [{ list: emptyList }] = result.current
+      expect(emptyList).toEqual([])
     })
   })
 })

--- a/src/__tests__/useStore.test.tsx
+++ b/src/__tests__/useStore.test.tsx
@@ -13,7 +13,9 @@ const useGlobal = useStore(
       store.resetState()
     },
   },
-  {},
+  {
+    initial: 'state',
+  },
 )
 
 describe('useStore functions', () => {
@@ -21,7 +23,9 @@ describe('useStore functions', () => {
     const { result } = renderHook(() => useGlobal())
     const [, { fillState }] = result.current
 
-    expect(result.current[0]).toEqual({})
+    expect(result.current[0]).toEqual({
+      initial: 'state',
+    })
 
     act(() => {
       fillState()
@@ -30,6 +34,7 @@ describe('useStore functions', () => {
     expect(result.current[0]).toEqual({
       foo: 'bar',
       baz: 'bat',
+      initial: 'state',
     })
   })
 
@@ -44,6 +49,7 @@ describe('useStore functions', () => {
     expect(result.current[0]).toEqual({
       foo: 'bar',
       baz: 'bat',
+      initial: 'state',
     })
 
     act(() => {

--- a/src/__tests__/useStore.test.tsx
+++ b/src/__tests__/useStore.test.tsx
@@ -1,16 +1,16 @@
-import { useStore } from '../useStore'
+import { Store, useStore } from '../useStore'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 const useGlobal = useStore(
   {
-    fillState: store => {
+    fillState: (store: Store) => {
       store.setState({
         foo: 'bar',
         baz: 'bat',
       })
     },
-    cleanState: store => {
-      store.resetState()
+    cleanState: (store: Store) => {
+      store.clearState()
     },
   },
   {

--- a/src/__tests__/useStore.test.tsx
+++ b/src/__tests__/useStore.test.tsx
@@ -1,0 +1,55 @@
+import { useStore } from '../useStore'
+import { renderHook, act } from '@testing-library/react-hooks'
+
+const useGlobal = useStore(
+  {
+    fillState: store => {
+      store.setState({
+        foo: 'bar',
+        baz: 'bat',
+      })
+    },
+    cleanState: store => {
+      store.resetState()
+    },
+  },
+  {},
+)
+
+describe('useStore functions', () => {
+  it('Sets state when given actions', () => {
+    const { result } = renderHook(() => useGlobal())
+    const [, { fillState }] = result.current
+
+    expect(result.current[0]).toEqual({})
+
+    act(() => {
+      fillState()
+    })
+
+    expect(result.current[0]).toEqual({
+      foo: 'bar',
+      baz: 'bat',
+    })
+  })
+
+  it('resets state correctly', () => {
+    const { result } = renderHook(() => useGlobal())
+    const [, { fillState, cleanState }] = result.current
+
+    act(() => {
+      fillState()
+    })
+
+    expect(result.current[0]).toEqual({
+      foo: 'bar',
+      baz: 'bat',
+    })
+
+    act(() => {
+      cleanState()
+    })
+
+    expect(result.current[0]).toEqual({})
+  })
+})

--- a/src/private/__tests__/actions.test.js
+++ b/src/private/__tests__/actions.test.js
@@ -11,6 +11,11 @@ describe('actions', () => {
       state = newState
       store.state = newState
     },
+    resetState: obj => {
+      const newState = { ...state, ...obj }
+      state = newState
+      store.state = {}
+    },
   }
 
   describe('getRequest', () => {
@@ -391,6 +396,26 @@ describe('actions', () => {
         destroying: false,
         destroyError: message,
       })
+    })
+  })
+
+  describe('resetState', () => {
+    it('Resets state', () => {
+      const getResult = actions.getRequest(store, {
+        operation: 'list',
+        name: 'get',
+        stateId: 'list',
+      })
+
+      expect(getResult).toBeTruthy()
+      expect(get(store.state, 'get@list')).toMatchObject({
+        fetchingList: true,
+        listError: null,
+      })
+
+      actions.resetState(store)
+
+      expect(store.state).toEqual({})
     })
   })
 })

--- a/src/private/__tests__/actions.test.js
+++ b/src/private/__tests__/actions.test.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
 
 import * as actions from '../actions'
+import { initialState } from '../initialState'
 
 describe('actions', () => {
   let state = {}
@@ -11,9 +12,7 @@ describe('actions', () => {
       state = newState
       store.state = newState
     },
-    resetState: obj => {
-      const newState = { ...state, ...obj }
-      state = newState
+    clearState: () => {
       store.state = {}
     },
   }
@@ -400,12 +399,9 @@ describe('actions', () => {
   })
 
   describe('resetState', () => {
-    it('Resets state', () => {
-      const getResult = actions.getRequest(store, {
-        operation: 'list',
-        name: 'get',
-        stateId: 'list',
-      })
+    it('resets the piece of state to the initialState', () => {
+      const options = { operation: 'list', name: 'get', stateId: 'list' }
+      const getResult = actions.getRequest(store, options)
 
       expect(getResult).toBeTruthy()
       expect(get(store.state, 'get@list')).toMatchObject({
@@ -413,8 +409,23 @@ describe('actions', () => {
         listError: null,
       })
 
-      actions.resetState(store)
+      actions.resetState(store, options)
+      expect(store.state['get@list']).toEqual(initialState)
+    })
+  })
 
+  describe('clearCroodsState', () => {
+    it('clears the whole croods global state', () => {
+      const options = { operation: 'list', name: 'get', stateId: 'list' }
+      const getResult = actions.getRequest(store, options)
+
+      expect(getResult).toBeTruthy()
+      expect(get(store.state, 'get@list')).toMatchObject({
+        fetchingList: true,
+        listError: null,
+      })
+
+      actions.clearCroodsState(store, options)
       expect(store.state).toEqual({})
     })
   })

--- a/src/private/actionHelpers.ts
+++ b/src/private/actionHelpers.ts
@@ -13,8 +13,14 @@ import type {
 } from 'types'
 import type { Store } from 'useStore'
 
-type Operation = 'INFO' | 'LIST' | 'SAVE' | 'DESTROY' | 'SET'
-type ActionType = 'REQUEST' | 'SUCCESS' | 'FAIL' | 'INFO' | 'LIST'
+type Operation = 'INFO' | 'LIST' | 'SAVE' | 'DESTROY' | 'SET' | 'CLEAR'
+type ActionType =
+  | 'REQUEST'
+  | 'SUCCESS'
+  | 'FAIL'
+  | 'INFO'
+  | 'LIST'
+  | 'STATE PIECE'
 type SetState = {
   (newPiece: CroodsState, callback?: (t: GlobalState) => void): void
 }

--- a/src/private/actions.ts
+++ b/src/private/actions.ts
@@ -13,6 +13,8 @@ import {
 import type { Operation } from './actionHelpers'
 import type { ActionOptions, CroodsData, ID, Info } from 'types'
 import type { Store } from 'useStore'
+import { initialState } from './initialState'
+import { consoleGroup } from './logger'
 
 type ObjWithId = { id: ID }
 type ActionError = { error: string; id?: ID }
@@ -242,8 +244,15 @@ const setInfoFromList = (
   return false
 }
 
-const resetState = (store: Store): void => {
-  store.resetState()
+const resetState = (store: Store, options: ActionOptions): void => {
+  const [, setState, log] = stateMiddleware(store, options)
+  setState(initialState, log('CLEAR', 'STATE PIECE'))
+}
+
+const clearCroodsState = (store: Store, options: ActionOptions): void => {
+  store.clearState()
+  if (options.debugActions)
+    consoleGroup('CLEARED CROODS STATE', 'red')(store.state)
 }
 
 export {
@@ -260,4 +269,5 @@ export {
   setList,
   setInfoFromList,
   resetState,
+  clearCroodsState,
 }

--- a/src/private/actions.ts
+++ b/src/private/actions.ts
@@ -242,6 +242,10 @@ const setInfoFromList = (
   return false
 }
 
+const resetState = (store: Store): void => {
+  store.resetState()
+}
+
 export {
   getRequest,
   getSuccess,
@@ -255,4 +259,5 @@ export {
   setInfo,
   setList,
   setInfoFromList,
+  resetState,
 }

--- a/src/private/findStatePiece.ts
+++ b/src/private/findStatePiece.ts
@@ -22,7 +22,7 @@ function findStatePiece(
       ...initialState,
       fetchingInfo: Boolean(initializeFetching && id),
       fetchingList: Boolean(initializeFetching && !id),
-    } // TODO: Remove these optional params as they aren't used
+    }
   )
 }
 

--- a/src/private/findStatePiece.ts
+++ b/src/private/findStatePiece.ts
@@ -22,7 +22,7 @@ function findStatePiece(
       ...initialState,
       fetchingInfo: Boolean(initializeFetching && id),
       fetchingList: Boolean(initializeFetching && !id),
-    }
+    } // TODO: Remove these optional params as they aren't used
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ type Actions<T = any> = {
   save: <B = T>(a?: SaveOptions) => (b?: ReqBody) => Promise<Info<B>>
   setInfo: <B = Partial<T>>(a: B, b?: boolean) => void
   setList: <B = T>(a: B[], b?: boolean) => void
+  resetState: () => void
   dangerouslyResetCroodsState: () => void
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ type Actions<T = any> = {
   setInfo: <B = Partial<T>>(a: B, b?: boolean) => void
   setList: <B = T>(a: B[], b?: boolean) => void
   resetState: () => void
-  dangerouslyResetCroodsState: () => void
+  dangerouslyClearCroodsState: () => void
 }
 
 type HeadersObj = Record<string, string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ type Actions<T = any> = {
   save: <B = T>(a?: SaveOptions) => (b?: ReqBody) => Promise<Info<B>>
   setInfo: <B = Partial<T>>(a: B, b?: boolean) => void
   setList: <B = T>(a: B[], b?: boolean) => void
+  dangerouslyResetCroodsState: () => void
 }
 
 type HeadersObj = Record<string, string>

--- a/src/useCroods.tsx
+++ b/src/useCroods.tsx
@@ -173,7 +173,17 @@ const useCroods = <T extends any = any>({
     fetchOnMount && fetch({ id: options.id })(options.query)
   }, [options.id, options.query, fetchOnMount])
 
-  return [piece, { fetch, save, destroy, setInfo, setList }]
+  return [
+    piece,
+    {
+      fetch,
+      save,
+      destroy,
+      setInfo,
+      setList,
+      dangerouslyResetCroodsState: actions.resetState,
+    },
+  ]
 }
 
 export { useCroods }

--- a/src/useCroods.tsx
+++ b/src/useCroods.tsx
@@ -169,6 +169,14 @@ const useCroods = <T extends any = any>({
     [actions, options],
   )
 
+  const resetState = useCallback(() => {
+    actions.resetState(options)
+  }, [actions, options])
+
+  const dangerouslyResetCroodsState = useCallback(() => {
+    actions.clearCroodsState(options)
+  }, [actions, options])
+
   useEffect(() => {
     fetchOnMount && fetch({ id: options.id })(options.query)
   }, [options.id, options.query, fetchOnMount])
@@ -181,7 +189,8 @@ const useCroods = <T extends any = any>({
       destroy,
       setInfo,
       setList,
-      dangerouslyResetCroodsState: actions.resetState,
+      resetState,
+      dangerouslyResetCroodsState,
     },
   ]
 }

--- a/src/useCroods.tsx
+++ b/src/useCroods.tsx
@@ -173,7 +173,7 @@ const useCroods = <T extends any = any>({
     actions.resetState(options)
   }, [actions, options])
 
-  const dangerouslyResetCroodsState = useCallback(() => {
+  const dangerouslyClearCroodsState = useCallback(() => {
     actions.clearCroodsState(options)
   }, [actions, options])
 
@@ -190,7 +190,7 @@ const useCroods = <T extends any = any>({
       setInfo,
       setList,
       resetState,
-      dangerouslyResetCroodsState,
+      dangerouslyClearCroodsState,
     },
   ]
 }

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -10,7 +10,7 @@ type ObjWithStore<T extends Record<string, any>> = {
 type Listener = [string | undefined, React.Dispatch<any>]
 type Store<T = Record<string, any>, U = Record<string, any>> = {
   setState(t: Record<string, unknown>, p?: string): void
-  resetState(): void
+  clearState(): void
   actions?: ObjWithStore<T>
   state: U
   listeners?: Listener[]
@@ -34,7 +34,7 @@ function setState(
   emitChanges(this, updateContext)
 }
 
-function resetState(this: Store) {
+function clearState(this: Store) {
   this.state = {}
   emitChanges(this, undefined, true)
 }
@@ -81,10 +81,10 @@ function useStore<T, U extends Record<string, any> = Record<string, any>>(
     state: initialState || {},
     listeners: [],
     setState: () => null,
-    resetState: () => null,
+    clearState: () => null,
   }
   store.setState = setState.bind(store)
-  store.resetState = resetState.bind(store)
+  store.clearState = clearState.bind(store)
   store.actions = associateActions(store, actions)
   return useCustom.bind(store) as UseGlobal<T, U>
 }


### PR DESCRIPTION
This PR introduces a minor feature: the ability to reset Croods state.

This can (and will) be used in cases when the application needs a completely clean state. This action does not send any request to the server and does not resets to the initial state: it completely replaces it with an empty object.

I also added docs and missing tests.

PS: there's a test case I'm not sure is correct. I'd love some help on writing it better.